### PR TITLE
fix custom conversion setup

### DIFF
--- a/src/main/kotlin/no/blommish/DatabaseConfiguration.kt
+++ b/src/main/kotlin/no/blommish/DatabaseConfiguration.kt
@@ -5,12 +5,12 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.postgresql.util.PGobject
 import org.springframework.boot.SpringBootConfiguration
+import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.convert.converter.Converter
 import org.springframework.data.convert.ReadingConverter
 import org.springframework.data.convert.WritingConverter
-import org.springframework.data.jdbc.core.convert.JdbcCustomConversions
 import org.springframework.data.jdbc.repository.config.AbstractJdbcConfiguration
 import org.springframework.data.jdbc.repository.config.EnableJdbcAuditing
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories
@@ -24,13 +24,12 @@ val objectMapper =
 @EnableJdbcRepositories("no.blommish")
 @SpringBootConfiguration // Appconfig
 class DatabaseConfiguration : AbstractJdbcConfiguration() {
+    
     @Bean
-    override fun jdbcCustomConversions(): JdbcCustomConversions {
-        return JdbcCustomConversions(
-            listOf(
-                PGobjectToMyJsonConverter(),
-                MyJsonToPGobjectConverter(),
-            ),
+    override fun userConverters(): List<*> {
+        return listOf(
+            PGobjectToMyJsonConverter(),
+            MyJsonToPGobjectConverter()
         )
     }
 

--- a/src/test/kotlin/no/blommish/BarRepositoryTest.kt
+++ b/src/test/kotlin/no/blommish/BarRepositoryTest.kt
@@ -11,6 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.ApplicationContextInitializer
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.data.convert.CustomConversions
+import org.springframework.data.relational.core.dialect.Dialect
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.junit.jupiter.SpringExtension
@@ -33,11 +34,15 @@ class LoggerInitializer : ApplicationContextInitializer<ConfigurableApplicationC
 class BarRepositoryTest {
     @Autowired
     lateinit var barRepository: BarRepository
-
+    @Autowired
+    lateinit var dialect : Dialect
     @Test
     fun `saving and getting db data`() {
         val bar = barRepository.save(Bar(data = MyJson("asd")))
-        barRepository.findByIdOrNull(bar.id)
+        val reloaded = barRepository.findByIdOrNull(bar.id)
+
+        assertThat(reloaded).isEqualTo(bar)
+
 
         assertThat(listAppender.list).isEmpty()
     }


### PR DESCRIPTION
Fixes the setup of custom conversions so `PGObject` and others are still properly considered simple types.